### PR TITLE
Implemented Basic Auth

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,5 @@ REF_SERVER_EXPOSED_PORT=8080
 REF_SERVER_URL=http://localhost:8080
 ODH_BASE_URL=http://tourism.opendatahub.bz.it/api/
 ODH_TIMEOUT=60000
+USERNAME=alpinebits
+PASSWORD=supersecret

--- a/package-lock.json
+++ b/package-lock.json
@@ -840,6 +840,14 @@
         }
       }
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1790,6 +1798,14 @@
             "ms": "2.0.0"
           }
         }
+      }
+    },
+    "express-basic-auth": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.0.tgz",
+      "integrity": "sha512-iJ0h1Gk6fZRrFmO7tP9nIbxwNgCUJASfNj5fb0Hy15lGtbqqsxpt7609+wq+0XlByZjXmC/rslWQtnuSTVRIcg==",
+      "requires": {
+        "basic-auth": "^2.0.1"
       }
     },
     "extend": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "custom-env": "^1.0.2",
     "express": "^4.17.1",
+    "express-basic-auth": "^1.2.0",
     "jsonapi-serializer": "^3.6.5",
     "sanitize-html": "^1.20.1",
     "sha.js": "^2.4.11"

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,4 +1,12 @@
 const types = {
+  noCredentials: {
+    title: "No credentials were provided.",
+    status: 401
+  },
+  credentialsRejected: {
+    title: "Credentials rejected.",
+    status: 401
+  },
   notFound: {
     title: "Resource(s) not found.",
     status: 404
@@ -43,6 +51,10 @@ function handleError(err, req, res ){
   res.json({ errors: [ err ] });
 }
 
+function createJSON(err) {
+  return ({ errors: [ err ] });
+}
+
 function handleNotImplemented(req, res){
   handleError(types.notImplemented, req, res);
 }
@@ -50,5 +62,6 @@ function handleNotImplemented(req, res){
 module.exports = {
   ...types,
   handleError,
-  handleNotImplemented
+  handleNotImplemented,
+  createJSON
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const cors = require('cors');
+const basicAuth = require('express-basic-auth');
+
 const errors = require('./errors');
 require('custom-env').env();
 
@@ -18,6 +20,19 @@ app.use( (req, res, next) => {
   console.log('> Request received: ' + process.env.REF_SERVER_URL + req.originalUrl);
   next();
 });
+
+app.use(basicAuth({
+    authorizer: (username, password) => {
+      const userMatches = basicAuth.safeCompare(username, process.env.USERNAME);
+      const passwordMatches = basicAuth.safeCompare(password, process.env.PASSWORD);
+      return userMatches & passwordMatches;
+    },
+    unauthorizedResponse: (req, res) => {
+      return req.auth
+        ? errors.createJSON(errors.credentialsRejected)
+        : errors.createJSON(errors.noCredentials)
+    }
+}))
 
 app.use( (req, res, next) => {
   res.setHeader('Content-Type', 'application/vnd.api+json');

--- a/src/server.js
+++ b/src/server.js
@@ -28,6 +28,7 @@ app.use(basicAuth({
       return userMatches & passwordMatches;
     },
     unauthorizedResponse: (req, res) => {
+      console.log('Unauthorized request ' + process.env.REF_SERVER_URL + req.originalUrl);
       return req.auth
         ? errors.createJSON(errors.credentialsRejected)
         : errors.createJSON(errors.noCredentials)

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1,5 +1,4 @@
 module.exports.basicRouteTests = (opts) => {
-  const axios = require('axios');
   const utils = require('./utils');
 
   let headers, status, meta, data, links;
@@ -106,23 +105,23 @@ module.exports.basicRouteTests = (opts) => {
     })
 
     test(`/${opts.route}: pagination 'next' link works`, () => {
-      return axios.get(links.next).then( res => expect(res.data.data).toBeDefined())
+      return utils.get(links.next).then( res => expect(res.data.data).toBeDefined())
     });
 
     test(`/${opts.route}: pagination 'prev' link works`, () => {
-      return axios.get(links.prev).then( res => expect(res.data.data).toBeDefined())
+      return utils.get(links.prev).then( res => expect(res.data.data).toBeDefined())
     });
 
     test(`/${opts.route}: pagination 'first' link works`, () => {
-      return axios.get(links.first).then( res => expect(res.data.data).toBeDefined())
+      return utils.get(links.first).then( res => expect(res.data.data).toBeDefined())
     });
 
     test(`/${opts.route}: pagination 'last' link works`, () => {
-      return axios.get(links.last).then( res => expect(res.data.data).toBeDefined())
+      return utils.get(links.last).then( res => expect(res.data.data).toBeDefined())
     });
 
     test(`/${opts.route}: 'self' link works`, () => {
-      return axios.get(links.self).then( res => {
+      return utils.get(links.self).then( res => {
         expect(res.data.data).toBeDefined()
         expect(res.data.data).toEqual(data);
         expect(res.data.links).toEqual(links);
@@ -134,7 +133,7 @@ module.exports.basicRouteTests = (opts) => {
       let i = 0;
 
       while(i<=3 && i<data.length-1){
-        promises.push(axios.get(data[i].links.self));
+        promises.push(utils.get(data[i].links.self));
         i++;
       }
 

--- a/test/route_id.test.js
+++ b/test/route_id.test.js
@@ -1,5 +1,4 @@
 module.exports.basicResourceRouteTests = (opts) => {
-  const axios = require('axios');
   const utils = require('./utils');
 
   describe(`API tests for 404 requests to /${opts.route}/:id`, () => {
@@ -151,7 +150,7 @@ module.exports.basicResourceRouteTests = (opts) => {
     })
 
     test(`/${opts.route}/:id: self link returns the same object`, () => {
-      return axios.get(links.self).then( res => {
+      return utils.get(links.self).then( res => {
         expect(res.data.data).toEqual(data);
         expect(res.data.links).toEqual(links);
       })
@@ -168,7 +167,7 @@ module.exports.basicResourceRouteTests = (opts) => {
         else {
           expect(rel.links).toBeDefined();
           expect(rel.links.related).toBeDefined();
-          promises.push(axios.get(rel.links.related));
+          promises.push(utils.get(rel.links.related));
         }
       });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,9 +1,48 @@
 const utils = require('./utils');
+const axios = require('axios');
 
-test('Unknown route returns 404 NOT FOUND', () => {
-  expect.assertions(1);
-  return utils.axiosInstance.get('/i-dont-exist')
-    .catch( (res) => {
-      expect(res.response.status).toEqual(404);
-    });
+describe(`Testing unknown route`, () => {
+  test('Unknown route returns 404 NOT FOUND', () => {
+    expect.assertions(1);
+    return utils.axiosInstance.get('/i-dont-exist')
+      .catch( (res) => {
+        expect(res.response.status).toEqual(404);
+      });
+  });
+});
+
+describe(`Refuse request without authentication`, () => {
+  let status, data;
+
+  beforeAll( () => {
+    return axios.get(process.env.REF_SERVER_URL+'/api/v1/events')
+      .catch( res =>  ({data, status} = res.response) );
+  });
+
+  test('Test HTTP Status 401 Unauthorized', () => {
+    expect(status).toEqual(401);
+  });
+
+  test('Test error message title', () => {
+    expect(data.errors.length).toEqual(1);
+    expect(data.errors[0].title).toEqual("No credentials were provided.");
+  });
+});
+
+describe(`Refuse request with invalid username and password`, () => {
+  let status, message;
+
+  beforeAll( () => {
+    return axios.get(process.env.REF_SERVER_URL+'/api/v1/events', { auth: { username: 'me', password: 'mypassword' }})
+      .catch( res =>  ({data, status} = res.response) );
+  });
+
+  test('Test HTTP Status 401 Unauthorized', () => {
+    expect(status).toEqual(401);
+  });
+
+  test('Test error message title', () => {
+    expect(data.errors.length).toEqual(1);
+    expect(data.errors[0].title).toEqual("Credentials rejected.");
+  });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,11 +1,19 @@
 const axios = require('axios');
 require('custom-env').env();
 
+const TIMEOUT = 300000;
+const AUTH = {
+  username: process.env.USERNAME,
+  password: process.env.PASSWORD
+}
+
 const axiosInstance = axios.create({
   baseURL: process.env.REF_SERVER_URL,
-  timeout: 300000,
+  timeout: TIMEOUT,
+  auth: AUTH
 });
 
 module.exports = {
-  axiosInstance
+  axiosInstance,
+  get: url => axios.get(url, { timeout: TIMEOUT, auth: AUTH })
 };


### PR DESCRIPTION
I implemented basic authentication (username + password) to protect the API endpoints. 

All requests should now be send with a header containing:

Authorization: Basic YWxwaW5lYml0czp3cm9uZ3Bhc3N3b3Jk

The **Basic** keyword identifies the authentication strategy and the following code is a string in the format **username:password**, but encoded in the base 64.

Requests without this header or with an invalid username and password should be rejected with the status code 401.

NOTE: HTTPS will be implemented in a next feature.